### PR TITLE
`common`, `docker` and placeholder `wordpress` Ansible roles

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,6 +5,7 @@ host_key_checking = False
 hash_behaviour = merge
 inventory = inventory.ini
 display_args_to_stdout = True
+command_warnings = False
 
 [ssh_connection]
 pipelining = False

--- a/provision.yml
+++ b/provision.yml
@@ -4,6 +4,6 @@
   become: yes
   roles:
     - role: common
-    - role: docker
+    - role: wordpress
 
 ...

--- a/provision.yml
+++ b/provision.yml
@@ -2,37 +2,8 @@
 
 - hosts: all
   become: yes
-  tasks:
-    - name: set timezone to europe/stockholm
-      copy: src=/usr/share/zoneinfo/Europe/Stockholm dest=/etc/localtime
-
-    - name: install ntp
-      yum: name=ntp state=present
-
-    - name: ntpd running and enabled
-      service: name=ntpd state=started enabled=yes
-
-    - name: install firewalld
-      yum: name=firewalld state=present
-
-    - name: firewalld running and enabled
-      service: name=firewalld state=started enabled=yes
-
-    - name: epel repo
-      yum_repository:
-        name: epel
-        description: EPEL YUM repo
-        baseurl: http://download.fedoraproject.org/pub/epel/$releasever/$basearch/
-        gpgkey: http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
-
-    - name: install epel-release
-      yum: name=epel-release state=present
-
-    - name: install htop, jq and python-pip
-      yum: name={{ item }} state=present
-      with_items:
-        - htop
-        - jq
-        - python-pip
+  roles:
+    - role: common
+    - role: docker
 
 ...

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -1,0 +1,22 @@
+---
+
+galaxy_info:
+  author: Victoria Tepliuk
+  description: Provisioning of commonly needed utilities and configurations.
+  company: vtepliuk Consulting
+
+  license: Apache-2.0
+
+  min_ansible_version: 2.5
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+
+  galaxy_tags:
+    - common
+
+dependencies: []
+
+...

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+
+- name: set timezone to europe/stockholm
+  copy: src=/usr/share/zoneinfo/Europe/Stockholm dest=/etc/localtime
+  tags: common
+
+- name: install ntp
+  yum: name=ntp state=present
+  tags: common
+
+- name: ntpd running and enabled
+  service: name=ntpd state=started enabled=yes
+  tags: common
+
+- name: install firewalld
+  yum: name=firewalld state=present
+  tags: common
+
+- name: firewalld running and enabled
+  service: name=firewalld state=started enabled=yes
+  tags: common
+
+- name: epel repo
+  yum_repository:
+    name: epel
+    description: EPEL YUM repo
+    baseurl: http://download.fedoraproject.org/pub/epel/$releasever/$basearch/
+    gpgkey: http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
+  tags: common
+
+- name: install epel-release
+  yum: name=epel-release state=present
+  tags: common
+
+- name: install htop, jq and python-pip
+  yum: name={{ item }} state=present
+  with_items:
+    - htop
+    - jq
+    - python-pip
+  tags: common
+
+...

--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -1,0 +1,22 @@
+---
+
+galaxy_info:
+  author: Victoria Tepliuk
+  description: Slightly modified version of https://github.com/mblomdahl/jenkins-up/tree/master/roles/docker
+  company: vtepliuk Consulting
+
+  license: Apache-2.0
+
+  min_ansible_version: 2.5
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+
+  galaxy_tags:
+    - docker
+
+dependencies: []
+
+...

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+
+- name: docker-ce repo
+  yum_repository:
+    name: docker-ce-stable
+    description: Docker CE Stable - $basearch
+    baseurl: https://download.docker.com/linux/centos/7/$basearch/stable
+    gpgkey: https://download.docker.com/linux/centos/gpg
+  tags: docker
+
+- name: install yum-versionlock-plugin
+  yum: name=yum-plugin-versionlock state=present
+  tags: docker
+
+- name: remove docker-ce version lock
+  shell: yum versionlock delete docker-ce
+  register: versionlock_delete_docker
+  changed_when: '"versionlock delete: no matches" in versionlock_delete_docker.stdout'
+  failed_when: no
+  tags: docker
+
+- name: install docker-ce-18.03.1.ce
+  yum: name=docker-ce-18.03.1.ce state=present allow_downgrade=yes
+  tags: docker
+
+- name: add docker-ce version lock
+  shell: yum versionlock docker-ce
+  changed_when: no
+  tags: docker
+
+- name: docker running and enabled
+  service: name=docker state=started enabled=yes
+  tags: docker
+
+...

--- a/roles/wordpress/meta/main.yml
+++ b/roles/wordpress/meta/main.yml
@@ -1,0 +1,24 @@
+---
+
+galaxy_info:
+  author: Victoria Tepliuk
+  description: Provisioning of WordPress application and database (both using Docker containers).
+  company: vtepliuk Consulting
+
+  license: Apache-2.0
+
+  min_ansible_version: 2.5
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+
+  galaxy_tags:
+    - wordpress
+    - mariadb
+
+dependencies:
+  - docker
+
+...

--- a/roles/wordpress/tasks/main.yml
+++ b/roles/wordpress/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: first placeholder task; should implement something like https://docs.docker.com/compose/wordpress/#define-the-project here
-  shell: echo "go to https://docs.docker.com/compose/wordpress/#define-the-project and implement in Ansible"
+- name: first placeholder task; should be completed by ...
+  shell: echo "TODO! Go to https://docs.docker.com/compose/wordpress/#define-the-project and implement equivalent in Ansible here"
   tags: wordpress, mariadb
 
 ...

--- a/roles/wordpress/tasks/main.yml
+++ b/roles/wordpress/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: first placeholder task; should implement something like https://docs.docker.com/compose/wordpress/#define-the-project here
+  shell: echo "go to https://docs.docker.com/compose/wordpress/#define-the-project and implement in Ansible"
+  tags: wordpress, mariadb
+
+...


### PR DESCRIPTION
This PR resolves #3 by taking the tasks from `provision.yml` playbook and putting them into the `common` role. Also adds a `docker` role based on the *jenkins-up* project and the placeholder `wordpress` role suggested in #3.